### PR TITLE
Update CloudFront URL to current distribution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      BASE_URL: ${{ vars.CLOUDFRONT_URL || 'https://d29r7pgg6vs29b.cloudfront.net' }}
+      BASE_URL: ${{ vars.CLOUDFRONT_URL || 'https://dcqt91rhtte69.cloudfront.net' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -142,7 +142,7 @@ jobs:
         working-directory: e2e
         run: npx playwright test
         env:
-          BASE_URL: ${{ vars.CLOUDFRONT_URL || 'https://d29r7pgg6vs29b.cloudfront.net' }}
+          BASE_URL: ${{ vars.CLOUDFRONT_URL || 'https://dcqt91rhtte69.cloudfront.net' }}
           ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
           ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   reporter: [['html', { open: 'never' }], ['list']],
 
   use: {
-    baseURL: process.env.BASE_URL ?? 'https://d29r7pgg6vs29b.cloudfront.net',
+    baseURL: process.env.BASE_URL ?? 'https://dcqt91rhtte69.cloudfront.net',
     viewport: { width: 1280, height: 720 },
     actionTimeout: 10_000,
     navigationTimeout: 15_000,


### PR DESCRIPTION
## Summary
- Updated hardcoded CloudFront fallback URL from `d29r7pgg6vs29b` to `dcqt91rhtte69` in:
  - `e2e/playwright.config.ts` (local E2E default)
  - `.github/workflows/deploy.yml` (CI E2E fallback, 2 occurrences)

## Root cause
AWS stack was recreated, generating a new CloudFront distribution. The old domain no longer resolves, causing all E2E tests to fail with `ERR_NAME_NOT_RESOLVED`.

Going forward, `munchgo-aws-iac/scripts/03-post-terraform-setup.sh` will auto-update these URLs on each rebuild.

## Test plan
- [ ] Verify `https://dcqt91rhtte69.cloudfront.net` resolves
- [ ] Run E2E tests locally: `cd e2e && npx playwright test`
- [ ] CI E2E tests pass on next deploy workflow run