### PR TITLE
Add STACK_STATUS pre-flight guard to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Check AWS stack is active
+        if: vars.STACK_STATUS == 'DESTROYED'
+        run: |
+          echo "::error::AWS stack is not active (STACK_STATUS=DESTROYED)."
+          echo "Run the infrastructure setup scripts before deploying:"
+          echo "  cd munchgo-aws-iac && terraform apply && ./scripts/03-post-terraform-setup.sh"
+          exit 1
+
       - uses: actions/download-artifact@v4
         with:
           name: dist


### PR DESCRIPTION
## Summary
- Deploy job checks `vars.STACK_STATUS` and fails fast with a clear error when the AWS stack has been destroyed
- Prevents cryptic S3/CloudFront failures when infrastructure doesn't exist

## Related PRs
- shanaka-versent/munchgo-aws-iac#25 — sets the variable in destroy/setup scripts
- shanaka-versent/munchgo-microservices — `feat/stack-status-sentinel`

## Test plan
- [ ] Verify deploy job has stack status check as first step
- [ ] Verify build job is NOT blocked (it doesn't touch AWS)
- [ ] Confirm `STACK_STATUS=ACTIVE` is set in repo variables